### PR TITLE
Add a fix for handling null values and merge move-to-bytes to master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ v4 = []
 appveyor = []
 
 [dependencies]
-bytes = "0.5.*"
+bytes = "1.0.0"
 byteorder = "1"
 log = "0.4.1"
 rand = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ v4 = []
 appveyor = []
 
 [dependencies]
-bytes = "0.6.*"
+bytes = "0.5.*"
 byteorder = "1"
 log = "0.4.1"
 rand = "0.4.1"
@@ -25,6 +25,6 @@ uuid = "0.8"
 num_enum = "0.4.2"
 syn = "1.0"
 quote = "1.0"
-serde = "1.0.106"
+serde = { version = "1.0.*", features = ["serde_derive"]}
 
 cbytes_macro_derive = { path = "./cbytes_macro_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ v4 = []
 appveyor = []
 
 [dependencies]
-bytes = "0.5.*"
+bytes = "0.6.*"
 byteorder = "1"
 log = "0.4.1"
 rand = "0.4.1"

--- a/src/compressors/no_compression.rs
+++ b/src/compressors/no_compression.rs
@@ -1,7 +1,7 @@
 use crate::compression::Compressor;
 use crate::error::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NoCompression {}
 
 impl NoCompression {

--- a/src/frame/frame_result.rs
+++ b/src/frame/frame_result.rs
@@ -290,6 +290,7 @@ pub struct RowsMetadata {
 impl IntoBytes for RowsMetadata {
     fn into_cbytes(&self) -> Vec<u8> {
         let mut temp: Vec<u8> = Vec::new();
+        temp.extend(ResultKind::Rows.into_cbytes());
         temp.extend_from_slice(&self.flags.to_be_bytes());
         temp.extend_from_slice(&self.columns_count.to_be_bytes());
         if let Some(ref state) = self.paging_state {

--- a/src/frame/parser.rs
+++ b/src/frame/parser.rs
@@ -1,27 +1,27 @@
-use std::io::{Cursor, Read};
 use super::*;
 use crate::compression::Compressor;
 use crate::error;
-use std::io;
 use crate::frame::frame_response::ResponseBody;
 use crate::frame::FromCursor;
 use crate::types::data_serialization_types::decode_timeuuid;
 use crate::types::{from_bytes, from_u16_bytes, CStringList, UUID_LEN};
-use bytes::{BytesMut};
+use bytes::{Buf, BytesMut};
+use std::io;
+use std::io::{Cursor, Read};
 
 #[derive(Debug, Clone)]
 pub struct FrameHeader {
-    version:  Version,
+    version: Version,
     flags: Vec<Flag>,
     stream: u16,
-    opcode : Opcode,
-    length : usize,
+    opcode: Opcode,
+    length: usize,
 }
 
 pub fn parse_frame<E>(
-    src: & mut BytesMut,
+    src: &mut BytesMut,
     compressor: &dyn Compressor<CompressorError = E>,
-    frame_header_original: &Option<FrameHeader>
+    frame_header_original: &Option<FrameHeader>,
 ) -> error::Result<(Option<Frame>, Option<FrameHeader>)>
 where
     E: std::error::Error,
@@ -31,16 +31,16 @@ where
     let max_frame_len = 1024 * 1024 * 15; //15MB
     let frame_header: FrameHeader;
 
-    if src.len() < head_len {
+    if src.len() < head_len && frame_header_original.is_none() {
         // Not enough data to read the head
         return Ok((None, None));
     }
 
-    let version:  Version;
+    let version: Version;
     let flags: Vec<Flag>;
     let stream: u16;
-    let opcode : Opcode;
-    let length : usize;
+    let opcode: Opcode;
+    let length: usize;
 
     // if we have a previous frame header, use that instead
     //
@@ -50,7 +50,6 @@ where
         stream = header.stream;
         opcode = header.opcode;
         length = header.length;
-
     } else {
         let mut version_bytes = [0; Version::BYTE_LENGTH];
         let mut flag_bytes = [0; Flag::BYTE_LENGTH];
@@ -79,21 +78,19 @@ where
         flags,
         stream,
         opcode,
-        length
+        length,
     };
 
     if (frame_header.length as usize) > max_frame_len {
         //TODO throw error
-        return Err(error::Error::Io(
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Max frame length exceeded",
-            )
-        ));
+        return Err(error::Error::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Max frame length exceeded",
+        )));
     }
-    src.reserve(frame_header.length);
 
     if src.len() < frame_header.length {
+        src.reserve(frame_header.length - src.len());
         return Ok((None, Some(frame_header)));
     }
 
@@ -105,7 +102,11 @@ where
     let mut outer_body_cursor = Cursor::new(src.split_to(frame_header.length));
     outer_body_cursor.read_exact(&mut body_bytes)?;
 
-    let full_body = if frame_header.flags.iter().any(|flag| flag == &Flag::Compression) {
+    let full_body = if frame_header
+        .flags
+        .iter()
+        .any(|flag| flag == &Flag::Compression)
+    {
         compressor
             .decode(body_bytes)
             .map_err(|err| error::Error::from(err.description()))?
@@ -145,7 +146,7 @@ where
         stream: frame_header.stream,
         body: body,
         tracing_id: tracing_id,
-        warnings: warnings,
+        warnings,
     };
 
     src.reserve(head_len);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -582,7 +582,7 @@ impl IntoBytes for CBytes {
                 v.extend_from_slice(b.as_slice());
                 v
             }
-            None => vec![],
+            None => vec![255, 255, 255, 255], // If NULL set to -1
         }
     }
 }


### PR DESCRIPTION
The length for null values should be set to -1. This is just a quick fix so I can unblock implementing peer port rewriting in Shotover. 

Also merge the `move-to-bytes` branch into `master` since it's the most up to date branch. 